### PR TITLE
[DOCS] Remove redundant code

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,12 +1,9 @@
 FROM node:alpine
 
-RUN mkdir /build
-
 COPY build build
 
 RUN npm -g install serve
 
-WORKDIR .
 EXPOSE 5000
 
 CMD ["serve", "-s", "build"]


### PR DESCRIPTION
```
RUN mkdir /build
```
This is not required as the next step copies the directory.

```
WORKDIR .
```
This sets the workdir to the current dir?