### PR TITLE
fix: [dashboard] closes #155

### DIFF
--- a/dashboard/src/pages/Publicpages/PasswordSetupReset.tsx
+++ b/dashboard/src/pages/Publicpages/PasswordSetupReset.tsx
@@ -148,6 +148,8 @@ export function SetPasswordComponent(props: SetPasswordComponentProps) {
   };
 
   const handleSubmit = (event: React.FormEvent<{}>) => {
+     event.preventDefault();
+
     if (data.password !== data.cpassword) {
       alert('Your passwords does not match')    
       return
@@ -162,7 +164,7 @@ export function SetPasswordComponent(props: SetPasswordComponentProps) {
 
     setLoader(true);
     const reqData = data;
-    event.preventDefault();
+   
 
     let url = `${Constants.TRASA_HOSTNAME}/api/woa/setup/password`;
     reqData.token = props.token;


### PR DESCRIPTION
missing `event.preventDefault()` at top of `handleSubmit` caused browser to reload in rejected submit function call. So when browser auto reloads the webpage, it also auto generates input data in urlQuery. 