### PR TITLE
Update dashboard node.js version in Dockerfile to v14

### DIFF
--- a/build/docker/dev/Dockerfile
+++ b/build/docker/dev/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /go/src/seknox/trasa/server
 RUN go build
 
 
-FROM node:13.12.0-alpine as dashbuilder
+FROM node:14.17.0-alpine as dashbuilder
 
 WORKDIR /trasa
 ENV PATH /trasa/node_modules/.bin:$PATH

--- a/build/docker/prod/Dockerfile
+++ b/build/docker/prod/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /go/src/seknox/trasa/server
 RUN go build
 
 
-FROM node:13.12.0-alpine as dashbuilder
+FROM node:14.17.0-alpine as dashbuilder
 
 WORKDIR /trasa
 ENV PATH /trasa/node_modules/.bin:$PATH

--- a/tests/build/e2e/Dockerfile
+++ b/tests/build/e2e/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /go/src/seknox/trasa/server
 RUN go build
 
 
-FROM node:13.12.0-alpine as dashbuilder
+FROM node:14.17.0-alpine as dashbuilder
 
 WORKDIR /trasa
 ENV PATH /trasa/node_modules/.bin:$PATH


### PR DESCRIPTION
Node.js v13 is EOL, and the version been using in the CI environment is
currently v14, see PR: #114, should be consistent.